### PR TITLE
Improve log level of verbose loggings

### DIFF
--- a/common/header.go
+++ b/common/header.go
@@ -63,7 +63,7 @@ func (h *Header) UnmarshalBinary(data []byte) error {
 	h.Length = binary.BigEndian.Uint16(data[2:4])
 	h.Xid = binary.BigEndian.Uint32(data[4:8])
 
-	klog.V(4).InfoS("UnmarshalBinary", "Header", h)
+	klog.V(7).InfoS("Header UnmarshalBinary", "Header", h)
 	return nil
 }
 

--- a/openflow15/flowmod.go
+++ b/openflow15/flowmod.go
@@ -121,10 +121,9 @@ func (f *FlowMod) MarshalBinary() (data []byte, err error) {
 			return
 		}
 		data = append(data, bytes...)
-		klog.V(4).InfoS("flowmod instr", "bytes", bytes)
 	}
 
-	klog.V(4).InfoS("Flowmod MarshalBinary succeeded", "dataLength", len(data), "data", data)
+	klog.V(7).InfoS("Flowmod MarshalBinary succeeded", "dataLength", len(data), "data", data)
 	return
 }
 

--- a/openflow15/flowstats.go
+++ b/openflow15/flowstats.go
@@ -53,27 +53,27 @@ func (s *Stats) MarshalBinary() (data []byte, err error) {
 }
 
 func (s *Stats) UnmarshalBinary(data []byte) (err error) {
-	klog.V(4).Infof("Stats Data: %x", data)
+	klog.V(7).InfoS("Stats Data", "data", data)
 	n := 2 // 2 bytes Reserved
 	s.Length = binary.BigEndian.Uint16(data[n:])
 	n += 2
-	klog.V(4).Infof("Stats Length: %d", s.Length)
+	klog.V(7).InfoS("Stats Length", "len", s.Length)
 	for n < int(s.Length) {
 		var f util.Message
-		klog.V(4).InfoS("Stats Field", "value", data[n+2]>>1)
+		klog.V(7).InfoS("Stats Field", "value", data[n+2]>>1)
 		switch data[n+2] >> 1 {
 		case XST_OFB_DURATION:
 			fallthrough
 		case XST_OFB_IDLE_TIME:
-			klog.V(4).InfoS("Received TimeStatField", "offset", n)
+			klog.V(7).InfoS("Received TimeStatField", "offset", n)
 			f = new(TimeStatField)
 		case XST_OFB_FLOW_COUNT:
-			klog.V(4).InfoS("Received FlowCountStatField", "offset", n)
+			klog.V(7).InfoS("Received FlowCountStatField", "offset", n)
 			f = new(FlowCountStatField)
 		case XST_OFB_PACKET_COUNT:
 			fallthrough
 		case XST_OFB_BYTE_COUNT:
-			klog.V(4).InfoS("Received PBCountStatField", "offset", n)
+			klog.V(7).InfoS("Received PBCountStatField", "offset", n)
 			f = new(PBCountStatField)
 		default:
 			return fmt.Errorf("Received unknown Stats field: %v", data[n+2]>>1)
@@ -185,7 +185,7 @@ func (f *TimeStatField) UnmarshalBinary(data []byte) (err error) {
 		return
 	}
 	n := f.Header.Len()
-	klog.V(4).Info("Header Len: %d", n)
+	klog.V(7).Info("Header Len: %d", n)
 	f.Sec = binary.BigEndian.Uint32(data[n:])
 	n += 4
 	f.NSec = binary.BigEndian.Uint32(data[n:])

--- a/openflow15/group.go
+++ b/openflow15/group.go
@@ -127,7 +127,6 @@ func (g *GroupMod) MarshalBinary() (data []byte, err error) {
 		}
 		data = append(data, bytes...)
 		g.BucketArrayLen += bkt.Len()
-		klog.V(4).InfoS("Groupmod bucket", "bytes", bytes)
 	}
 
 	for _, p := range g.Properties {
@@ -137,8 +136,8 @@ func (g *GroupMod) MarshalBinary() (data []byte, err error) {
 		}
 		data = append(data, bytes...)
 	}
-	klog.V(4).InfoS("GroupMod MarshalBinary succeeded", "dataLength", len(data), "data", data)
 
+	klog.V(7).InfoS("GroupMod MarshalBinary succeeded", "dataLength", len(data), "data", data)
 	return
 }
 

--- a/openflow15/meter.go
+++ b/openflow15/meter.go
@@ -268,10 +268,9 @@ func (m *MeterMod) MarshalBinary() (data []byte, err error) {
 		}
 		copy(data[n:], mbBytes)
 		n += METER_BAND_LEN
-		klog.V(4).InfoS("Metermod band", "bytes", mbBytes)
 	}
 
-	klog.V(4).InfoS("Metermod MarshalBinary succeeded", "dataLength", len(data), "data", data)
+	klog.V(7).InfoS("Metermod MarshalBinary succeeded", "dataLength", len(data), "data", data)
 
 	return
 }

--- a/openflow15/multipart.go
+++ b/openflow15/multipart.go
@@ -51,7 +51,7 @@ func (s *MultipartRequest) MarshalBinary() (data []byte, err error) {
 		data = append(data, b...)
 	}
 
-	klog.V(4).InfoS("Sending MultipartRequest succeeded", "dataLength", len(data), "data", data)
+	klog.V(7).InfoS("MultipartRequest MarshalBinary succeeded", "dataLength", len(data), "data", data)
 
 	return
 }
@@ -2177,10 +2177,10 @@ func (f *FlowDesc) UnmarshalBinary(data []byte) (err error) {
 		return
 	}
 	m_len := f.Match.Len()
-	klog.V(4).InfoS("Match Len", "value", m_len)
+	klog.V(7).InfoS("Match Len", "value", m_len)
 	n += m_len
 
-	klog.V(4).InfoS("Data passed to Stats UnmarshalBinary", "data", data[n:])
+	klog.V(7).InfoS("Data passed to Stats UnmarshalBinary", "data", data[n:])
 	err = f.Stats.UnmarshalBinary(data[n:])
 	if err != nil {
 		klog.ErrorS(err, "Failed to unmarshal FlowDesc's Stats", "data", data[n:])

--- a/openflow15/openflow15.go
+++ b/openflow15/openflow15.go
@@ -112,7 +112,7 @@ const (
 )
 
 func Parse(b []byte) (message util.Message, err error) {
-	klog.V(4).InfoS("Openflow15 parse", "bytes", b)
+	klog.V(7).InfoS("Parsing Openflow15 message", "dataLength", len(b), "data", b)
 	switch b[1] {
 	case Type_Error:
 		errMsg := new(ErrorMsg)
@@ -198,7 +198,7 @@ func Parse(b []byte) (message util.Message, err error) {
 	if message != nil {
 		err = message.UnmarshalBinary(b)
 	}
-	klog.V(4).InfoS("Parsing result", "error", err, "message", message)
+	klog.V(7).InfoS("Parsed Openflow15 message", "error", err, "message", message)
 	return
 }
 
@@ -2239,7 +2239,7 @@ func (c *BndleAdd) MarshalBinary() (data []byte, err error) {
 	if err != nil {
 		return
 	}
-	klog.V(4).InfoS("BndleAdd MarshalBinary", "Header", c.Header)
+	klog.V(7).InfoS("BndleAdd MarshalBinary", "Header", c.Header)
 	var n uint16
 	copy(data[n:], b)
 	n = c.Header.Len()

--- a/util/stream.go
+++ b/util/stream.go
@@ -125,7 +125,12 @@ func (m *MessageStream) outbound() {
 				m.Shutdown <- true
 			}
 
-			klog.V(4).InfoS("Sent", "dataLength", len(data), "data", len(data), data)
+			// Only log the data with loglevel >= 7.
+			if klogV := klog.V(7); klogV.Enabled() {
+				klogV.InfoS("Sent outbound message", "dataLength", len(data), "data", data)
+			} else {
+				klog.V(4).InfoS("Sent outbound message", "dataLength", len(data))
+			}
 		}
 	}
 }


### PR DESCRIPTION
The OpenFlow messages are rather long and flooding the log file. In most cases developers are not interested in the data of the messages while V(4) is a widely used level for application logs.

The patch improves their log levels to 7, removes some redundant logs, and fixes a log format issue in stream.go, which messed up log files.