### PR TITLE
Allocate 6 bytes to copy MAC addresses when unmarshalling ethernet ma…

### DIFF
--- a/openflow13/match.go
+++ b/openflow13/match.go
@@ -657,6 +657,7 @@ func (m *EthDstField) MarshalBinary() (data []byte, err error) {
 }
 
 func (m *EthDstField) UnmarshalBinary(data []byte) error {
+	m.EthDst = make([]byte, 6)
 	copy(m.EthDst, data)
 	return nil
 }
@@ -700,6 +701,7 @@ func (m *EthSrcField) MarshalBinary() (data []byte, err error) {
 }
 
 func (m *EthSrcField) UnmarshalBinary(data []byte) error {
+	m.EthSrc = make([]byte, 6)
 	copy(m.EthSrc, data)
 	return nil
 }

--- a/openflow15/match.go
+++ b/openflow15/match.go
@@ -856,6 +856,7 @@ func (m *EthDstField) MarshalBinary() (data []byte, err error) {
 }
 
 func (m *EthDstField) UnmarshalBinary(data []byte) error {
+	m.EthDst = make([]byte, 6)
 	copy(m.EthDst, data)
 	return nil
 }
@@ -899,6 +900,7 @@ func (m *EthSrcField) MarshalBinary() (data []byte, err error) {
 }
 
 func (m *EthSrcField) UnmarshalBinary(data []byte) error {
+	m.EthSrc = make([]byte, 6)
 	copy(m.EthSrc, data)
 	return nil
 }


### PR DESCRIPTION
…tch fields

Currently we are trying to unmarshal data to an uninitialized struct whose net.HardwareAddr fields are set to nil. In this case the copy() function silently does nothing.

Initialize the fields to slices of bytes of length 6 before copying data to them.

This commit is derived from #30.