### PR TITLE
Fix openflow15 GroupMod.MarshalBinary to correctly handle marshaling twice.

### DIFF
--- a/openflow15/group.go
+++ b/openflow15/group.go
@@ -126,7 +126,6 @@ func (g *GroupMod) MarshalBinary() (data []byte, err error) {
 			return
 		}
 		data = append(data, bytes...)
-		g.BucketArrayLen += bkt.Len()
 	}
 
 	for _, p := range g.Properties {

--- a/openflow15_test.go
+++ b/openflow15_test.go
@@ -87,6 +87,13 @@ func validateOpenflowMessage(m util.Message, n util.Message) error {
 		return err
 	}
 
+	// check that marshalling doesn't change internal state
+	x2, err := n.MarshalBinary()
+	if err != nil {
+		fmt.Printf("Second MarshalBinary failed with error code: %v", err)
+		return err
+	}
+
 	// Debug block
 	if false { // set to true if you want to write second pass message to be
 		// written to the pcap file as well.
@@ -110,6 +117,12 @@ func validateOpenflowMessage(m util.Message, n util.Message) error {
 	if bytes.Equal(b, x) == false {
 		var myErr MyError
 		myErr.s = "MarshalBinary bytes don't match with original"
+		return myErr
+	}
+
+	if bytes.Equal(x, x2) == false {
+		var myErr MyError
+		myErr.s = "Results of first and second run of MarshalBinary are different"
 		return myErr
 	}
 	return nil


### PR DESCRIPTION
During experiments with stress testing of flow/group insertion into OVS, I've came across a small bug in GroupMod marshaling, when doing it more than one time.

I've modified tests to check no other message is affected. 

I'll be glad if someone will look at it. Thanks in advance!