### PR TITLE
Allocate 6 bytes to copy MAC addresses when unmarshalling ethernet match fields #30

### DIFF
--- a/openflow13/match.go
+++ b/openflow13/match.go
@@ -657,6 +657,7 @@ func (m *EthDstField) MarshalBinary() (data []byte, err error) {
 }
 
 func (m *EthDstField) UnmarshalBinary(data []byte) error {
+	m.EthDst = make([]byte, 6)
 	copy(m.EthDst, data)
 	return nil
 }
@@ -700,6 +701,7 @@ func (m *EthSrcField) MarshalBinary() (data []byte, err error) {
 }
 
 func (m *EthSrcField) UnmarshalBinary(data []byte) error {
+	m.EthSrc = make([]byte, 6)
 	copy(m.EthSrc, data)
 	return nil
 }

--- a/openflow15/match.go
+++ b/openflow15/match.go
@@ -856,6 +856,7 @@ func (m *EthDstField) MarshalBinary() (data []byte, err error) {
 }
 
 func (m *EthDstField) UnmarshalBinary(data []byte) error {
+	m.EthDst = make([]byte, 6)
 	copy(m.EthDst, data)
 	return nil
 }
@@ -899,6 +900,7 @@ func (m *EthSrcField) MarshalBinary() (data []byte, err error) {
 }
 
 func (m *EthSrcField) UnmarshalBinary(data []byte) error {
+	m.EthSrc = make([]byte, 6)
 	copy(m.EthSrc, data)
 	return nil
 }

--- a/openflow15/match_test.go
+++ b/openflow15/match_test.go
@@ -1,0 +1,55 @@
+package openflow15_test
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"testing"
+
+	"antrea.io/libOpenflow/openflow15"
+)
+
+func TestMatchEthAddresses(t *testing.T) {
+	ethSrcAddress, _ := net.ParseMAC("aa:aa:aa:aa:aa:aa")
+	ethDstAddress, _ := net.ParseMAC("ff:ff:ff:ff:ff:ff")
+
+	ofMatch := openflow15.NewMatch()
+	{
+		macSrcField := openflow15.NewEthSrcField(ethSrcAddress, nil)
+		ofMatch.AddField(*macSrcField)
+
+		macDstField := openflow15.NewEthDstField(ethDstAddress, nil)
+		ofMatch.AddField(*macDstField)
+	}
+
+	if err := checkMatchSerializationConsistency(ofMatch); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func checkMatchSerializationConsistency(ofMatch *openflow15.Match) error {
+	// Serialize the original match
+	ofMatchRaw, err := ofMatch.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("failed to marshal match: %w", err)
+	}
+
+	// Deserialize into a new match object
+	ofMatchRecovered := openflow15.NewMatch()
+	if err := ofMatchRecovered.UnmarshalBinary(ofMatchRaw); err != nil {
+		return fmt.Errorf("failed to unmarshal match: %w", err)
+	}
+
+	// Serialize the recovered match for comparison
+	ofMatchRecoveredRaw, err := ofMatchRecovered.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("failed to marshal recovered match: %w", err)
+	}
+
+	// Check for serialization consistency
+	if !bytes.Equal(ofMatchRaw, ofMatchRecoveredRaw) {
+		return fmt.Errorf("initial and recovered match structures do not match")
+	}
+
+	return nil
+}


### PR DESCRIPTION
This request is nothing more than a continuation of the work on pool request #30, started by Mr. Rozhkov.