### PR TITLE
Fix PropExperimenter deserialization out-of-bounds read

### DIFF
--- a/openflow15/group.go
+++ b/openflow15/group.go
@@ -162,7 +162,7 @@ func (g *GroupMod) UnmarshalBinary(data []byte) (err error) {
 	g.CommandBucketId = binary.BigEndian.Uint32(data[n:])
 	n += 4
 
-	for len(g.Buckets) < int(g.BucketArrayLen) && n < g.Header.Length {
+	for len(g.Buckets) < int(g.BucketArrayLen) {
 		bkt := new(Bucket)
 		err = bkt.UnmarshalBinary(data[n:])
 		if err != nil {

--- a/openflow15/group.go
+++ b/openflow15/group.go
@@ -162,7 +162,7 @@ func (g *GroupMod) UnmarshalBinary(data []byte) (err error) {
 	g.CommandBucketId = binary.BigEndian.Uint32(data[n:])
 	n += 4
 
-	for n < g.Header.Length {
+	for len(g.Buckets) < int(g.BucketArrayLen) && n < g.Header.Length {
 		bkt := new(Bucket)
 		err = bkt.UnmarshalBinary(data[n:])
 		if err != nil {

--- a/openflow15/group.go
+++ b/openflow15/group.go
@@ -162,7 +162,7 @@ func (g *GroupMod) UnmarshalBinary(data []byte) (err error) {
 	g.CommandBucketId = binary.BigEndian.Uint32(data[n:])
 	n += 4
 
-	for len(g.Buckets) < int(g.BucketArrayLen) {
+	for n < g.BucketArrayLen+24 {
 		bkt := new(Bucket)
 		err = bkt.UnmarshalBinary(data[n:])
 		if err != nil {

--- a/openflow15/openflow15.go
+++ b/openflow15/openflow15.go
@@ -1509,8 +1509,6 @@ func (p *PropExperimenter) Len() uint16 {
 	n += 8
 	l := uint16(len(p.Data) * 4)
 	n += l
-	//n += uint16((8 - (l % 8)) % 8)  // pad to make multiple of 8
-	n += uint16(8 - (l % 8)) // pad to make multiple of 8
 	return n
 }
 

--- a/openflow15/openflow15.go
+++ b/openflow15/openflow15.go
@@ -1516,7 +1516,7 @@ func (p *PropExperimenter) Len() uint16 {
 
 func (p *PropExperimenter) MarshalBinary() (data []byte, err error) {
 	data = make([]byte, int(p.Len()))
-	p.Header.Length = 8 + uint16(len(p.Data)*4)
+	p.Header.Length = p.Header.Len() + 8 + uint16(len(p.Data)*4)
 	b, err := p.Header.MarshalBinary()
 	if err != nil {
 		return
@@ -1547,7 +1547,7 @@ func (p *PropExperimenter) UnmarshalBinary(data []byte) (err error) {
 	p.ExpType = binary.BigEndian.Uint32(data[n:])
 	n += 4
 
-	for n < p.Header.Length+p.Header.Len() {
+	for n < p.Header.Length {
 		d := binary.BigEndian.Uint32(data[n:])
 		p.Data = append(p.Data, d)
 		n += 4


### PR DESCRIPTION
Property example (from ovs, https://github.com/openvswitch/ovs/blob/dc7663f13ce73e69e2983af77a0342f216467b31/lib/ofp-group.c#L1210 )
[255 255 0 40 0 0 21 77 0 0 0 1 0 0 0 0 104 97 115 104 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]